### PR TITLE
sbt 0.13.x support for SCCT and use of stable scalatest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 outline.asc
 effective_akka.log
+target/
+.history

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ scalaVersion := "2.10.2"
 
 name := "Effective Akka"
 
-seq(ScctPlugin.instrumentSettings : _*)
+ScctPlugin.instrumentSettings
 
 libraryDependencies ++= Seq(
-          "com.typesafe.akka" %% "akka-actor" % "2.1.4",
-          "com.typesafe.akka" %% "akka-slf4j" % "2.1.4",
-          "com.typesafe.akka" %% "akka-testkit" % "2.1.4" % "test",
-          "ch.qos.logback" % "logback-classic" % "1.0.10",
-	  "org.scalatest" %% "scalatest" % "2.0.M6-SNAP22" % "test"
+  "com.typesafe.akka" %% "akka-actor" % "2.1.4",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.1.4",
+  "com.typesafe.akka" %% "akka-testkit" % "2.1.4" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.0.10",
+  "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
 )
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,3 @@
 resolvers += Classpaths.typesafeResolver
 
-resolvers += "scct-github-repository" at "http://mtkopone.github.com/scct/maven-repo"
-
-addSbtPlugin("reaktor" % "sbt-scct" % "0.2-SNAPSHOT")
+addSbtPlugin("com.sqality.scct" % "sbt-scct" % "0.2.2")


### PR DESCRIPTION
Added new plugin version of SCCT https://github.com/sqality/scct, change scalatest version from snapshot to final in order to avoid error java.lang.AbstractMethodError: org.scalatest.tools.Framework$ScalaTestRunner.tasks, finally added more filters to .gitignore
